### PR TITLE
Valid empty code string

### DIFF
--- a/src/components/MonacoField/MonacoField.js
+++ b/src/components/MonacoField/MonacoField.js
@@ -11,7 +11,11 @@ const MonacoField = ({language, theme, code, options, ...rest}) => {
       width="100%"
       language={language || 'javascript'}
       theme="vs-dark"
-      value={code || defaultCode}
+      value={
+        typeof code === 'string'
+          ? code
+          : defaultCode
+      }
       options={options || defaultOptions}
       {...rest}
     />


### PR DESCRIPTION
In previous, empty string is turned into a falsy value so _defaultCode_ is set as editor value, but an empty string is a possible value of editor.