### PR TITLE
Issue 28 solving

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,6 @@
 [lints]
 
 [options]
-all=true
+
 
 [strict]

--- a/src/components/InformationTabs/InformationTabsView.js
+++ b/src/components/InformationTabs/InformationTabsView.js
@@ -1,49 +1,45 @@
-import React from 'react';
-import { PropTypes } from 'prop-types';
-import { Tabs, Tab, TabList, TabPanel } from 'react-tabs';
-import _ from 'lodash';
-import 'react-tabs/style/react-tabs.css';
+import React from "react";
+import { PropTypes } from "prop-types";
+import { Tabs, Tab, TabList, TabPanel } from "react-tabs";
+import "react-tabs/style/react-tabs.css";
 
-import Output from '../Output';
-import CandidateInformation from '../CandidateInformation';
-import Evaluation from '../Evaluation';
+import { withStyles } from "@material-ui/core/styles";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import styles from "./styles";
 
-function InformationTabsView({
-  data, loading, activeTab, onChangeActiveTab
-}) {
-  const tabs = [
-    { id: 'output', name: 'Output', component: <Output {...data} /> },
-    { id: 'candidate_information', name: 'Candidate Information', component: <CandidateInformation {...data} /> },
-    { id: 'evaluation', name: 'Evaluation', component: <Evaluation {...data} /> },
-  ];
-
-  return (
-    <div style={{ backgroundColor: '#FFFFFF' }}>
-      <Tabs defaultIndex={_.findIndex(tabs, ['id', activeTab])}>
-        <TabList>
-          {tabs.map(tab => (
-            <Tab key={tab.id}>
-              {tab.name}
-            </Tab>
-          ))}
-        </TabList>
-        {tabs.map(tab => (
-          <TabPanel key={tab.id}>
-            {tab.component}
-          </TabPanel>
-        ))}
+const InformationTabsView = ({
+  data,
+  loading,
+  tabs,
+  activeTab,
+  onChangeActiveTab,
+  role,
+  classes
+}) => (
+  <div style={{ backgroundColor: "#FFFFFF" }}>
+    {loading ? (
+      <CircularProgress
+        classes={{ root: classes.loading }}
+        size={200}
+        color="secondary"
+      />
+    ) : (
+      <Tabs defaultIndex={0}>
+        <TabList>{tabs.map(tab => <Tab key={tab.id}>{tab.name}</Tab>)}</TabList>
+        {tabs.map(tab => <TabPanel key={tab.id}>{tab.component}</TabPanel>)}
       </Tabs>
-    </div>
-  );
-}
+    )}
+  </div>
+);
 
 InformationTabsView.propTypes = {
   data: PropTypes.shape({
-    task: PropTypes.string,
+    task: PropTypes.string
   }).isRequired,
   loading: PropTypes.bool.isRequired,
   activeTab: PropTypes.string.isRequired,
   onChangeActiveTab: PropTypes.func.isRequired,
+  classes: PropTypes.object.isRequired
 };
 
-export default InformationTabsView;
+export default withStyles(styles)(InformationTabsView);

--- a/src/components/InformationTabs/index.js
+++ b/src/components/InformationTabs/index.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
+import _ from "lodash";
 import InformationTabsView from './InformationTabsView';
+import Output from "../Output";
+import CandidateInformation from "../CandidateInformation";
+import Evaluation from "../Evaluation";
 
 class InformationTabs extends Component {
   constructor(props, context) {
@@ -10,27 +14,87 @@ class InformationTabs extends Component {
       activeTab,
       data: {},
       loading: true,
+      role: "",
+      tabs: []
     };
 
     this.onChangeActiveTab = this.onChangeActiveTab.bind(this);
   }
 
   componentDidMount() {
+
+    // hardcoded role and data, its needed a mockserver provider
+    const role = "evaluator"
+
     const data = {
       task: 'This is the task',
     };
-    this.setState({ data, loading: false });
+    
+    const tabs = [
+      {
+        id: "output",
+        name: "Output",
+        permissions: ['candidate', 'observer', 'evaluator'],
+        component: <Output {...data} />
+      },
+      {
+        id: "candidate_information",
+        name: "Candidate Information",
+        permissions: ['observer', 'evaluator'],
+        component: <CandidateInformation {...data} />
+      },
+      {
+        id: "evaluation",
+        name: "Evaluation",
+        permissions: ['evaluator'],
+        component: <Evaluation {...data} />
+      }
+    ];
+
+   // setTimeout just to watch the animation...
+   // must be removed when connected to real server
+   setTimeout(() => (this.setState({ data, loading: false, role, tabs })), 1000);
+   
   }
 
   onChangeActiveTab(activeTab) {
     this.setState({ activeTab });
   }
 
+  filterTabs = (inclutions, tabs) => {
+    const filter = [];
+    tabs.forEach((tab, idx) => {
+      if (inclutions[idx]) {
+        filter.push(tab);
+      }
+    });
+
+    return filter;
+  };
+
   render() {
+
+    const { role, tabs, activeTab, loading } = this.state;
+    const inclutions = [];
+    const defaultIndex = _.findIndex(tabs, ["id", activeTab]);
+
+    // check roles in tabs permissions array
+    // and adds it into a truth array
+    tabs.forEach((tab, idx) => {
+      const { permissions } = tab;
+      const truth = permissions.includes(role);
+      inclutions.splice(idx, 1, truth);
+    });
+
+    // filtered tabs based in truth array
+    const roleTabs = this.filterTabs(inclutions, tabs)
     return (
       <InformationTabsView
         onChangeActiveTab={this.onChangeActiveTab}
         {...this.state}
+        tabs={roleTabs}
+        defaultIndex={defaultIndex}
+        loading={loading}
       />
     );
   }

--- a/src/components/InformationTabs/styles.js
+++ b/src/components/InformationTabs/styles.js
@@ -1,0 +1,9 @@
+const styles = theme => ({
+  loading: {
+    position: "absolute",
+    top: "8em",
+    left: "8em"
+  }
+});
+
+export default styles;

--- a/src/components/Instructions/InstructionsView.js
+++ b/src/components/Instructions/InstructionsView.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 
-function InstructionsView({ data, loading }) {
-  return (
+import { withStyles } from "@material-ui/core/styles";
+import CircularProgress from '@material-ui/core/CircularProgress';
+import styles from "./styles";
+
+const InstructionsView = ({ data, loading, classes }) => (
     <div className="panel">
       <div className="title">
         <h1>
@@ -11,11 +14,12 @@ function InstructionsView({ data, loading }) {
       </div>
       { loading
         ? (
-          <span>
-            Loading...
-          </span>
-        )
-        : (
+          <CircularProgress
+            classes={{ root: classes.loading }}
+            size={75}
+            color="secondary"
+          />
+        ) : (
           <span>
             {data.instructions}
           </span>
@@ -23,14 +27,13 @@ function InstructionsView({ data, loading }) {
       }
     </div>
   );
-}
-
 
 InstructionsView.propTypes = {
   data: PropTypes.shape({
     instructions: PropTypes.string,
   }).isRequired,
   loading: PropTypes.bool.isRequired,
+  classes: PropTypes.object.isRequired,
 };
 
-export default InstructionsView;
+export default withStyles(styles)(InstructionsView);

--- a/src/components/Instructions/index.js
+++ b/src/components/Instructions/index.js
@@ -14,7 +14,10 @@ class Instructions extends Component {
   componentDidMount() {
     api.get('/challenges/id').then((response) => {
       if (response.status === 200) {
-        this.setState({ data: response.data.data, loading: false });
+       
+      // setTimeout just to watch the animation...
+      // must be removed when connected to real server
+      setInterval(() => (this.setState({ data: response.data.data, loading: false })), 1000) ;
       }
     });
   }

--- a/src/components/Instructions/styles.js
+++ b/src/components/Instructions/styles.js
@@ -1,0 +1,9 @@
+const styles = theme => ({
+  loading: {
+    position: "absolute",
+    top: "3.5em",
+    left: "25em"
+  }
+});
+
+export default styles;

--- a/src/components/Welcome/Welcome.js
+++ b/src/components/Welcome/Welcome.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { Redirect } from "react-router-dom";
 
@@ -6,23 +6,62 @@ import { withStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
+import CircularProgress from '@material-ui/core/CircularProgress';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
 
 import logo from "../../assets/img/logo.svg";
 import footerLogo from "../../assets/img/jobsity-footer.png";
 import styles from "./styles";
+import { api } from "../../mockServer";
 
 class Welcome extends Component {
   state = {
-    toMain: false
+    isLoading: true,
+    toMain: false,
+    chal: false,
+    cand: false,
+    lock: false,
+    challengeData: {},
+    candidateData: {}
   };
+
+  componentDidMount() {
+    // mock server calls 
+    api.get("/challenges/id").then(response => {
+      if (response.status === 200) {
+        this.setState({ challengeData: response.data.data, chal: true });
+      }
+    });
+
+    api.get("/candidates/:id").then(response => {
+      if (response.status === 200) {
+        this.setState({ candidateData: response.data.data, cand: true });
+      }
+    });
+  }
+
+  componentDidUpdate() {
+    const { chal, cand, lock } = this.state;
+
+    // this state change only executes once
+    if (chal && cand && !lock) {
+      console.log("loaded all!");
+
+      // setTimeout just to watch the animation...
+      // must be removed when connected to real server
+      setTimeout(() =>(this.setState({ isLoading: false, lock: true })), 1000)
+      
+    }
+  }
 
   goToMain = () => this.setState({ toMain: true });
 
   render() {
     const { classes } = this.props;
-    const { toMain } = this.state;
+    const { challengeData, candidateData, toMain, isLoading } = this.state;
+    const { first_name, last_name } = candidateData;
+    const { languages, max_time, name } = challengeData;
 
     if (toMain) {
       return <Redirect to="/home" />;
@@ -30,10 +69,10 @@ class Welcome extends Component {
 
     // to be injected in props
     const data = {
-      lang: "JAVASCRIPT",
-      candidate: "John Doe",
-      test: "Test LIA 1",
-      time: 60
+      languages,
+      candidate: `${first_name} ${last_name}`,
+      test: name,
+      time: max_time
     };
 
     return (
@@ -46,22 +85,29 @@ class Welcome extends Component {
             component="h3">
             Welcome to Jobsity Live Coding
           </Typography>
-          <Typography className={classes.par} component="p">
-            {`Hello ${
-              data.candidate
-            }!, today we gonna work on a live coding excercise, please
+          {isLoading && 
+            <CircularProgress classes={{root: classes.loading}} size={200} className={classes.progress} color="secondary" />}
+          {!isLoading && (
+            <Fragment>
+              <Typography className={classes.par} component="p">
+                {`Hello ${
+                  data.candidate
+                }!, today we gonna work on a live coding excercise, please
           follow the instructions in the next screen, good luck!`}
-          </Typography>
-          <Paper square elevation="0" className={classes.subPaper}>
-            <Typography className={classes.headline} variant="title">
-              JAVASCRIPT
-            </Typography>
-            <Typography variant="caption">{data.test}</Typography>
-            <Typography variant="body2" gutterBottom>
-              <FontAwesomeIcon className={classes.icon} icon={faClock} />
-              {` ${data.time} minutes`}
-            </Typography>
-          </Paper>
+              </Typography>
+              <Paper square elevation="0" className={classes.subPaper}>
+                {languages.map(lan => (
+                  <Typography className={classes.headline} variant="title">
+                    {lan.toUpperCase()}
+                  </Typography>
+                ))}
+                <Typography variant="caption">{data.test}</Typography>
+                <Typography variant="body2" gutterBottom>
+                  <FontAwesomeIcon className={classes.icon} icon={faClock} />
+                  {` ${data.time}`}
+                </Typography>
+              </Paper>
+           
           <Button
             onClick={this.goToMain}
             fullWidth
@@ -71,6 +117,8 @@ class Welcome extends Component {
             className={classes.button}>
             Start Coding!
           </Button>
+          </Fragment>
+        )}
           <Typography className={classes.help} variant="caption">
             --- need help? ---
           </Typography>

--- a/src/components/Welcome/styles.js
+++ b/src/components/Welcome/styles.js
@@ -42,6 +42,9 @@ const styles = theme => ({
   help: {
     marginTop: theme.spacing.unit * 3
   },
+  loading:{
+    padding: "2em",
+  },
   footer: {
     display: "block",
     position: "absolute",


### PR DESCRIPTION
- [x] **Added role support for tabs in main layout**
By creating a permissions array inside each tab object with supported roles as strings inside.
Tabs will render if the chosen role exist inside its permissions array
- [x]  **Welcome screen data is now from mocked server**
Candidate and challenge info is now provided from server
- [x] **Added loading assets**
Material UI CircularProgress loading animations included, shown by default the first second using setTimeout (it will be for now just for presentation, further it will change when connected to a real server)