### PR TITLE
Data of played events can be easily used by any reducer

### DIFF
--- a/src/actions/playback.js
+++ b/src/actions/playback.js
@@ -1,11 +1,38 @@
 import * as actionTypes from './types';
 
-export const setPlayedEvents = playedEvents => ({
-  type: actionTypes.PLAYBACK_EVENTS_SET,
-  payload: {
-    playedEvents,
-  },
-});
+// Internal functions (not exported)
+
+const classifier = (eventsData, { data, type }) => {
+  if (type in eventsData) {
+    eventsData[type].push(data);
+  } else {
+    eventsData[type] = [data];
+  }
+
+  return eventsData;
+};
+
+const classifyEventsData = playedEvents => {
+  if (playedEvents.length === 0) {
+    return {};
+  }
+
+  return playedEvents.reduce(classifier, {});
+}
+
+// Exported action creators
+
+export const setPlayedEvents = playedEvents => {
+  const eventsData = classifyEventsData(playedEvents);
+
+  return {
+    type: actionTypes.PLAYBACK_EVENTS_SET,
+    payload: {
+      eventsData,
+      playedEvents,
+    },
+  };
+};
 
 export const setIsPlaying = isPlaying => ({
   type: actionTypes.PLAYBACK_PLAYING_SET,

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -133,7 +133,7 @@ class Editor extends Component {
 };
 
 const mapState = state => ({
-  changes: fromReducers.getPlayedEventsData(state, 'editor'),
+  changes: fromReducers.getEditorChanges(state),
   code: fromReducers.getEditorCode(state),
   language: fromReducers.getLanguage(state),
   startingTime: fromReducers.getStartingTime(state),

--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -1,6 +1,7 @@
 import * as actionTypes from '../actions/types';
 
-const initState ={
+const initState = {
+  changes: [],
   code: null,
 };
 
@@ -15,11 +16,18 @@ export default (state = initState, action) => {
         code,
       };
     }
+    case actionTypes.PLAYBACK_EVENTS_SET:
+      return {
+        ...state,
+        changes: action.payload.eventsData.editor || [],
+      }
     default:
       return state;
   }
 }
 
 // Getters
+
+export const getChanges = state => state.changes;
 
 export const getCode = state => state.code;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,9 +4,9 @@ import challenge, * as fromChallenge from './challenge';
 import editor, * as fromEditor from './editor';
 import evaluation from './evaluation';
 import playback, * as fromPlayback from './playback';
-import session, * as fromSession from  './session';
+import session, * as fromSession from './session';
 import output, * as fromOutput from './output';
-import timeline, * as fromTimeline from  './timeline';
+import timeline, * as fromTimeline from './timeline';
 
 export default combineReducers({
   challenge,
@@ -20,6 +20,9 @@ export default combineReducers({
 
 
 // Editor getters
+
+export const getEditorChanges = state =>
+  fromEditor.getChanges(state.editor);
 
 export const getEditorCode = state =>
   fromEditor.getCode(state.editor);
@@ -92,18 +95,3 @@ export const getTestsResults = state =>
 // Session getters
 export const getLanguage = state =>
   fromSession.getLanguage(state.session);
-
-// Custom getters
-export const getPlayedEventsData = (state, type = null) => {
-  let playedEvents = getPlayedEvents(state);
-
-  if (!playedEvents) {
-    return playedEvents;
-  }
-
-  if (typeof type === 'string' && type.length > 0) {
-    playedEvents = playedEvents.filter(e => e.type === type);
-  }
-
-  return playedEvents.map(e => e.data);
-}

--- a/src/reducers/output.js
+++ b/src/reducers/output.js
@@ -1,9 +1,10 @@
 import {
+  PLAYBACK_EVENTS_SET,
   RUN_SAMPLE_TESTS_SUCCESS,
   RUN_SAMPLE_TESTS_ERROR,
   SUBMIT_CHALLENGE_SUCCESS,
   SUBMIT_CHALLENGE_ERROR,
-} from '../actions/types'; 
+} from '../actions/types';
 
 const initialState = {
   testsResults: null,
@@ -11,6 +12,21 @@ const initialState = {
 
 export default function (state = initialState, action) {
   switch (action.type) {
+    case PLAYBACK_EVENTS_SET: {
+      const { output } = action.payload.eventsData;
+
+      if (!output || output.length === 0) {
+        return {
+          ...state,
+          testsResults: null,
+        };
+      }
+
+      return {
+        ...state,
+        testsResults: output[output.length - 1],
+      };
+    }
     case RUN_SAMPLE_TESTS_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
Note: there is a commit ahead of current PR that should have been added. Please check it and merge it.

Data of played events is now classified based on events types when played events are assigned. Thus, any reducer can just listen PLAYBACK_EVENTS_SET action type, and extract its corresponding event data from _eventsData_ _payload_ property.

Example:

```
case actionTypes.PLAYBACK_EVENTS_SET:
  return {
    ..state,
    changes: action.payload.eventsData.editor || [],
  };
```