### PR TITLE
feature/redux-store-scheme-editor-playback-timeline updates

### DIFF
--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -3,6 +3,7 @@ import * as actionTypes from '../actions/types';
 const initState = {
   changes: [],
   code: null,
+  resetCounter: 0,
 };
 
 export default (state = initState, action) => {
@@ -21,6 +22,11 @@ export default (state = initState, action) => {
         ...state,
         changes: action.payload.eventsData.editor || [],
       }
+    case actionTypes.RESET_EDITORS:
+    return {
+      ...state,
+      resetCounter: state.resetCounter + 1,
+    }
     default:
       return state;
   }
@@ -31,3 +37,5 @@ export default (state = initState, action) => {
 export const getChanges = state => state.changes;
 
 export const getCode = state => state.code;
+
+export const getResetCounter = state => state.resetCounter;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -98,18 +98,3 @@ export const getLanguage = state =>
 
 export const getUser = state =>
   fromSession.getUser(state.session);
-
-// Custom getters
-export const getPlayedEventsData = (state, type = null) => {
-  let playedEvents = getPlayedEvents(state);
-
-  if (!playedEvents) {
-    return playedEvents;
-  }
-
-  if (typeof type === 'string' && type.length > 0) {
-    playedEvents = playedEvents.filter(e => e.type === type);
-  }
-
-  return playedEvents.map(e => e.data);
-}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -27,6 +27,8 @@ export const getEditorChanges = state =>
 export const getEditorCode = state =>
   fromEditor.getCode(state.editor);
 
+export const getEditorResetCounter = state =>
+  fromEditor.getResetCounter(state.editor);
 
 // Playback getters
 


### PR DESCRIPTION
- ```getPlayedEventsData``` getter was deleted from reducer.
- ```resetCounter``` editor state was added to handle editor resets.